### PR TITLE
Add YAML extension support

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_plain_text_converter.py
@@ -27,6 +27,8 @@ ACCEPTED_FILE_EXTENSIONS = [
     ".markdown",
     ".json",
     ".jsonl",
+    ".yml",
+    ".yaml",
 ]
 
 

--- a/packages/markitdown/tests/_test_vectors.py
+++ b/packages/markitdown/tests/_test_vectors.py
@@ -164,6 +164,28 @@ GENERAL_TEST_VECTORS = [
         must_not_include=[],
     ),
     FileTestVector(
+        filename="test.yaml",
+        mimetype="application/x-yaml",
+        charset="ascii",
+        url=None,
+        must_include=[
+            "12345678-1234-5678-1234-567812345678",
+            "87654321-4321-8765-4321-876543218765",
+        ],
+        must_not_include=[],
+    ),
+    FileTestVector(
+        filename="test.yml",
+        mimetype="application/x-yaml",
+        charset="ascii",
+        url=None,
+        must_include=[
+            "12345678-1234-5678-1234-567812345678",
+            "87654321-4321-8765-4321-876543218765",
+        ],
+        must_not_include=[],
+    ),
+    FileTestVector(
         filename="test_rss.xml",
         mimetype="text/xml",
         charset="utf-8",

--- a/packages/markitdown/tests/test_files/test.yaml
+++ b/packages/markitdown/tests/test_files/test.yaml
@@ -1,0 +1,7 @@
+key1: string_value
+key2: 1234
+key3:
+  - list_value1
+  - list_value2
+uuid_key: 12345678-1234-5678-1234-567812345678
+uuid_value: 87654321-4321-8765-4321-876543218765

--- a/packages/markitdown/tests/test_files/test.yml
+++ b/packages/markitdown/tests/test_files/test.yml
@@ -1,0 +1,7 @@
+key1: string_value
+key2: 1234
+key3:
+  - list_value1
+  - list_value2
+uuid_key: 12345678-1234-5678-1234-567812345678
+uuid_value: 87654321-4321-8765-4321-876543218765


### PR DESCRIPTION
## Summary
- update plain text converter to accept `.yml` and `.yaml`
- add sample YAML files for tests
- test that YAML files are converted correctly

## Testing
- `pre-commit run --all-files`
- `GITHUB_ACTIONS=1 pytest packages/markitdown/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6877dd1a123c832bb8d0526dcaede06e